### PR TITLE
Wire card ids through the API for MFGUI

### DIFF
--- a/services/ui_backend_service/api/card.py
+++ b/services/ui_backend_service/api/card.py
@@ -93,7 +93,7 @@ class CardsApi(object):
         if not cards:
             return web_response(404, {'data': []})
 
-        card_hashes = [{"hash": hash, "type": data["type"]} for hash, data in cards.items()]
+        card_hashes = [{"id": data["id"], "hash": hash, "type": data["type"]} for hash, data in cards.items()]
 
         # paginate list of cards
         limit, page, offset = get_pagination_params(request)

--- a/services/ui_backend_service/data/cache/get_cards_action.py
+++ b/services/ui_backend_service/data/cache/get_cards_action.py
@@ -48,6 +48,7 @@ class GetCards(GetData):
         """
         def _card_item(card):
             return {
+                "id": card.id,
                 "type": card.type,
                 "html": card.get()
             }

--- a/services/ui_backend_service/requirements.txt
+++ b/services/ui_backend_service/requirements.txt
@@ -5,4 +5,4 @@ throttler==1.2.0
 psycopg2
 aiopg
 pygit2==1.6.1
-git+https://github.com/valayDave/metaflow.git@67e19#egg=metaflow
+git+https://github.com/valayDave/metaflow.git@67e19

--- a/services/ui_backend_service/requirements.txt
+++ b/services/ui_backend_service/requirements.txt
@@ -5,4 +5,4 @@ throttler==1.2.0
 psycopg2
 aiopg
 pygit2==1.6.1
-git+https://github.com/valayDave/metaflow.git@67e19
+metaflow

--- a/services/ui_backend_service/requirements.txt
+++ b/services/ui_backend_service/requirements.txt
@@ -5,3 +5,4 @@ throttler==1.2.0
 psycopg2
 aiopg
 pygit2==1.6.1
+git+https://github.com/valayDave/metaflow.git@67e19

--- a/services/ui_backend_service/requirements.txt
+++ b/services/ui_backend_service/requirements.txt
@@ -5,4 +5,4 @@ throttler==1.2.0
 psycopg2
 aiopg
 pygit2==1.6.1
-metaflow==git+https://github.com/valayDave/metaflow.git@67e19
+git+https://github.com/valayDave/metaflow.git@67e19#egg=metaflow

--- a/services/ui_backend_service/requirements.txt
+++ b/services/ui_backend_service/requirements.txt
@@ -5,4 +5,4 @@ throttler==1.2.0
 psycopg2
 aiopg
 pygit2==1.6.1
-metaflow
+metaflow>=2.4.7

--- a/services/ui_backend_service/requirements.txt
+++ b/services/ui_backend_service/requirements.txt
@@ -5,4 +5,4 @@ throttler==1.2.0
 psycopg2
 aiopg
 pygit2==1.6.1
-git+https://github.com/valayDave/metaflow.git@67e19
+metaflow==git+https://github.com/valayDave/metaflow.git@67e19


### PR DESCRIPTION
Passes the card ID's to the API so that MFGUI can read them.

This PR is in concert with https://github.com/Netflix/metaflow-ui/pull/53. Neither of these two PR's will boirk if the other one has not been deployed