### PR TITLE
Add request-scoped DB query tracing to metadata service

### DIFF
--- a/services/data/postgres_async_db.py
+++ b/services/data/postgres_async_db.py
@@ -13,6 +13,7 @@ from typing import List, Tuple
 from .db_utils import DBResponse, DBPagination, aiopg_exception_handling, \
     get_db_ts_epoch_str, translate_run_key, translate_task_key, new_heartbeat_ts
 from .models import FlowRow, RunRow, StepRow, TaskRow, MetadataRow, ArtifactRow
+from . import query_tracing
 from services.utils import DBConfiguration, USE_SEPARATE_READER_POOL
 
 from services.data.service_configs import max_connection_retires, \
@@ -249,10 +250,35 @@ class AsyncPostgresTable(object):
                           expanded=False, limit: int = 0, offset: int = 0,
                           cur: aiopg.Cursor = None, serialize: bool = True) -> Tuple[DBResponse, DBPagination]:
         async def _execute_on_cursor(_cur):
-            await _cur.execute(select_sql, values)
+            tracer = query_tracing.get_active_tracer()
+            query_started_at = time.perf_counter() if tracer else None
+
+            try:
+                await _cur.execute(select_sql, values)
+                records = await _cur.fetchall()
+            except Exception as error:
+                if tracer:
+                    tracer.record_query(
+                        table_name=self.table_name,
+                        row_count=0,
+                        db_time_ms=(time.perf_counter() - query_started_at) * 1000,
+                        success=False,
+                        error_type=error.__class__.__name__,
+                        sql_template=select_sql,
+                    )
+                raise
+
+            row_count = len(records)
+            if tracer:
+                tracer.record_query(
+                    table_name=self.table_name,
+                    row_count=row_count,
+                    db_time_ms=(time.perf_counter() - query_started_at) * 1000,
+                    success=True,
+                    sql_template=select_sql,
+                )
 
             rows = []
-            records = await _cur.fetchall()
             if serialize:
                 for record in records:
                     # pylint-initial-ignore: Lack of __init__ makes this too hard for pylint
@@ -262,14 +288,12 @@ class AsyncPostgresTable(object):
             else:
                 rows = records
 
-            count = len(rows)
-
             # Will raise IndexError in case fetch_single=True and there's no results
             body = rows[0] if fetch_single else rows
             pagination = DBPagination(
                 limit=limit,
                 offset=offset,
-                count=count,
+                count=row_count,
                 page=math.floor(int(offset) / max(int(limit), 1)) + 1,
             )
             return body, pagination

--- a/services/data/query_tracing.py
+++ b/services/data/query_tracing.py
@@ -1,0 +1,135 @@
+import os
+import time
+from contextvars import ContextVar
+
+from aiohttp import web
+from services.utils import logging
+
+QUERY_TRACING_ENABLED = os.environ.get("QUERY_TRACING_ENABLED", "0") == "1"
+QUERY_TRACING_HEADER = "X-Metaflow-Trace-DB"
+QUERY_TRACING_SQL_PREVIEW_LIMIT = 200
+
+_TRUTHY_VALUES = {"1", "true", "yes", "on"}
+_active_db_tracer = ContextVar("active_db_tracer", default=None)
+
+logger = logging.getLogger("QueryTracing")
+
+
+class DBQueryTracer(object):
+    def __init__(self, capture_query_details: bool = False):
+        self.capture_query_details = capture_query_details
+        self.query_count = 0
+        self.total_rows = 0
+        self.total_db_time_ms = 0.0
+        self.queries = [] if capture_query_details else None
+        self._started_at = time.perf_counter()
+        self._token = None
+
+    def __enter__(self):
+        self._token = _active_db_tracer.set(self)
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        if self._token is not None:
+            _active_db_tracer.reset(self._token)
+        return False
+
+    def record_query(self, table_name: str, row_count: int, db_time_ms: float,
+                     success: bool, error_type: str = None, sql_template: str = None):
+        self.query_count += 1
+        self.total_rows += row_count
+        self.total_db_time_ms += db_time_ms
+
+        if self.capture_query_details:
+            self.queries.append({
+                "table": table_name,
+                "rows": row_count,
+                "time_ms": db_time_ms,
+                "success": success,
+                "error_type": error_type,
+                "sql": _truncate_sql(sql_template),
+            })
+
+    def request_time_ms(self):
+        return (time.perf_counter() - self._started_at) * 1000
+
+    def summary(self):
+        return {
+            "query_count": self.query_count,
+            "total_rows": self.total_rows,
+            "db_time_ms": self.total_db_time_ms,
+            "request_time_ms": self.request_time_ms(),
+        }
+
+
+def _truncate_sql(sql_template: str):
+    if sql_template is None:
+        return None
+    return sql_template[:QUERY_TRACING_SQL_PREVIEW_LIMIT]
+
+
+def get_active_tracer():
+    if not QUERY_TRACING_ENABLED:
+        return None
+    return _active_db_tracer.get()
+
+
+def request_tracing_requested(request: web.Request):
+    if not QUERY_TRACING_ENABLED:
+        return False
+
+    header_value = request.headers.get(QUERY_TRACING_HEADER)
+    if header_value is None:
+        return False
+    return header_value.strip().lower() in _TRUTHY_VALUES
+
+
+def _log_request_trace(request: web.Request, tracer: DBQueryTracer,
+                       response: web.StreamResponse = None, error: Exception = None):
+    status = response.status if response is not None else getattr(error, "status", 500 if error else "unknown")
+    summary = tracer.summary()
+
+    logger.info(
+        "[RequestTrace] %s %s status=%s query_count=%d total_rows=%d db_time_ms=%.2f request_time_ms=%.2f",
+        request.method,
+        request.path,
+        status,
+        summary["query_count"],
+        summary["total_rows"],
+        summary["db_time_ms"],
+        summary["request_time_ms"],
+    )
+
+    if tracer.capture_query_details:
+        for index, query in enumerate(tracer.queries, start=1):
+            logger.debug(
+                "[QueryTrace %d/%d] table=%s success=%s row_count=%d db_time_ms=%.2f error_type=%s sql=%s",
+                index,
+                tracer.query_count,
+                query["table"],
+                query["success"],
+                query["rows"],
+                query["time_ms"],
+                query["error_type"],
+                query["sql"],
+            )
+
+
+@web.middleware
+async def query_tracing_middleware(request, handler):
+    if not request_tracing_requested(request):
+        return await handler(request)
+
+    response = None
+    error = None
+    capture_query_details = logger.isEnabledFor(logging.DEBUG)
+
+    with DBQueryTracer(capture_query_details=capture_query_details) as tracer:
+        try:
+            response = await handler(request)
+            return response
+        except Exception as ex:
+            error = ex
+            raise
+        finally:
+            _log_request_trace(request, tracer, response=response, error=error)

--- a/services/metadata_service/server.py
+++ b/services/metadata_service/server.py
@@ -13,6 +13,7 @@ from .api.admin import AuthApi
 
 from .api.metadata import MetadataApi
 from services.data.postgres_async_db import AsyncPostgresDB
+import services.data.query_tracing as query_tracing
 from services.utils import DBConfiguration
 
 PATH_PREFIX = os.environ.get("PATH_PREFIX", "")
@@ -23,6 +24,8 @@ def app(loop=None, db_conf: DBConfiguration = None, middlewares=None, path_prefi
     loop = loop or asyncio.get_event_loop()
 
     _app = web.Application(loop=loop)
+    if query_tracing.QUERY_TRACING_ENABLED:
+        _app.middlewares.append(query_tracing.query_tracing_middleware)
     app = web.Application(loop=loop) if path_prefix else _app
     async_db = AsyncPostgresDB()
     loop.run_until_complete(async_db._init(db_conf))

--- a/services/metadata_service/tests/integration_tests/query_tracing_test.py
+++ b/services/metadata_service/tests/integration_tests/query_tracing_test.py
@@ -1,0 +1,128 @@
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from .utils import (
+    init_app,
+    init_db,
+    clean_db,
+    cli,
+    db,
+    add_flow,
+    add_run,
+    add_step,
+    add_task,
+)
+import services.data.query_tracing as query_tracing
+
+pytestmark = [pytest.mark.integration_tests]
+
+
+def _request_trace_records(caplog):
+    return [
+        record for record in caplog.records
+        if record.name == "QueryTracing" and "[RequestTrace]" in record.message
+    ]
+
+
+@pytest.fixture
+async def traced_cli(aiohttp_client):
+    with patch.object(query_tracing, "QUERY_TRACING_ENABLED", True):
+        cli = await init_app(aiohttp_client)
+        yield cli
+
+
+@pytest.fixture
+async def traced_db(traced_cli):
+    async_db = await init_db(traced_cli)
+    yield async_db
+    await clean_db(async_db)
+
+
+async def test_query_tracing_runs_endpoint_with_header(traced_cli, traced_db, caplog):
+    await add_flow(traced_db, flow_id="HelloFlow")
+    await add_run(traced_db, flow_id="HelloFlow", run_id="run-1")
+    await add_run(traced_db, flow_id="HelloFlow", run_id="run-2")
+
+    with caplog.at_level(logging.INFO, logger="QueryTracing"):
+        response = await traced_cli.get(
+            "/flows/HelloFlow/runs",
+            headers={query_tracing.QUERY_TRACING_HEADER: "1"},
+        )
+        await response.text()
+
+    trace_records = _request_trace_records(caplog)
+    assert response.status == 200
+    assert len(trace_records) == 1
+    assert "status=200" in trace_records[0].message
+    assert "query_count=1" in trace_records[0].message
+    assert "total_rows=2" in trace_records[0].message
+
+
+async def test_query_tracing_tasks_endpoint_with_header(traced_cli, traced_db, caplog):
+    _flow = (await add_flow(traced_db, flow_id="HelloFlow")).body
+    _run = (await add_run(traced_db, flow_id=_flow.get("flow_id"), run_id="run-1")).body
+    _step = (await add_step(
+        traced_db,
+        flow_id=_run.get("flow_id"),
+        step_name="start",
+        run_number=_run.get("run_number"),
+        run_id=_run.get("run_id"),
+    )).body
+    await add_task(
+        traced_db,
+        flow_id=_step.get("flow_id"),
+        step_name=_step.get("step_name"),
+        run_number=_step.get("run_number"),
+        run_id=_step.get("run_id"),
+        task_name="task-1",
+    )
+    await add_task(
+        traced_db,
+        flow_id=_step.get("flow_id"),
+        step_name=_step.get("step_name"),
+        run_number=_step.get("run_number"),
+        run_id=_step.get("run_id"),
+        task_name="task-2",
+    )
+
+    with caplog.at_level(logging.INFO, logger="QueryTracing"):
+        response = await traced_cli.get(
+            "/flows/{flow_id}/runs/{run_number}/steps/{step_name}/tasks".format(**_step),
+            headers={query_tracing.QUERY_TRACING_HEADER: "1"},
+        )
+        await response.text()
+
+    trace_records = _request_trace_records(caplog)
+    assert response.status == 200
+    assert len(trace_records) == 1
+    assert "query_count=2" in trace_records[0].message
+    assert "total_rows=3" in trace_records[0].message
+
+
+async def test_query_tracing_without_header_emits_no_trace(traced_cli, traced_db, caplog):
+    await add_flow(traced_db, flow_id="HelloFlow")
+    await add_run(traced_db, flow_id="HelloFlow", run_id="run-1")
+
+    with caplog.at_level(logging.INFO, logger="QueryTracing"):
+        response = await traced_cli.get("/flows/HelloFlow/runs")
+        await response.text()
+
+    assert response.status == 200
+    assert _request_trace_records(caplog) == []
+
+
+async def test_query_tracing_disabled_even_with_header(cli, db, caplog):
+    await add_flow(db, flow_id="HelloFlow")
+    await add_run(db, flow_id="HelloFlow", run_id="run-1")
+
+    with caplog.at_level(logging.INFO, logger="QueryTracing"):
+        response = await cli.get(
+            "/flows/HelloFlow/runs",
+            headers={query_tracing.QUERY_TRACING_HEADER: "1"},
+        )
+        await response.text()
+
+    assert response.status == 200
+    assert _request_trace_records(caplog) == []

--- a/services/metadata_service/tests/integration_tests/utils.py
+++ b/services/metadata_service/tests/integration_tests/utils.py
@@ -6,6 +6,7 @@ import psycopg2
 import psycopg2.extras
 from aiohttp import web
 from services.data.postgres_async_db import AsyncPostgresDB
+import services.data.query_tracing as query_tracing
 from services.utils.tests import get_test_dbconf
 from services.metadata_service.api.admin import AuthApi
 from services.metadata_service.api.flow import FlowApi
@@ -25,6 +26,8 @@ from services.migration_service.data.postgres_async_db import \
 
 async def init_app(aiohttp_client, queue_ttl=30):
     app = web.Application()
+    if query_tracing.QUERY_TRACING_ENABLED:
+        app.middlewares.append(query_tracing.query_tracing_middleware)
 
     # Migration routes as a subapp
     migration_app = web.Application()

--- a/services/metadata_service/tests/unit_tests/query_tracing_test.py
+++ b/services/metadata_service/tests/unit_tests/query_tracing_test.py
@@ -1,0 +1,210 @@
+import asyncio
+import logging
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import make_mocked_request
+
+import services.data.query_tracing as query_tracing
+from services.data.postgres_async_db import AsyncFlowTablePostgres
+
+pytestmark = [pytest.mark.unit_tests]
+
+
+class _SuccessfulCursor(object):
+    def __init__(self, records):
+        self._records = records
+
+    async def execute(self, *_args, **_kwargs):
+        return None
+
+    async def fetchall(self):
+        return self._records
+
+
+class _FailingCursor(object):
+    async def execute(self, *_args, **_kwargs):
+        raise RuntimeError("boom")
+
+    async def fetchall(self):
+        return []
+
+
+def _query_trace_records(caplog):
+    return [
+        record for record in caplog.records
+        if record.name == "QueryTracing" and "[RequestTrace]" in record.message
+    ]
+
+
+def _query_detail_records(caplog):
+    return [
+        record for record in caplog.records
+        if record.name == "QueryTracing" and "[QueryTrace " in record.message
+    ]
+
+
+def test_db_query_tracer_context_cleanup():
+    with patch.object(query_tracing, "QUERY_TRACING_ENABLED", True):
+        assert query_tracing.get_active_tracer() is None
+        with query_tracing.DBQueryTracer() as tracer:
+            assert query_tracing.get_active_tracer() is tracer
+        assert query_tracing.get_active_tracer() is None
+
+
+def test_request_tracing_requested_requires_enabled_header():
+    request = make_mocked_request(
+        "GET",
+        "/flows",
+        headers={query_tracing.QUERY_TRACING_HEADER: "1"},
+    )
+
+    with patch.object(query_tracing, "QUERY_TRACING_ENABLED", False):
+        assert query_tracing.request_tracing_requested(request) is False
+
+    with patch.object(query_tracing, "QUERY_TRACING_ENABLED", True):
+        assert query_tracing.request_tracing_requested(request) is True
+        assert query_tracing.request_tracing_requested(
+            make_mocked_request("GET", "/flows")
+        ) is False
+        assert query_tracing.request_tracing_requested(
+            make_mocked_request(
+                "GET",
+                "/flows",
+                headers={query_tracing.QUERY_TRACING_HEADER: "false"},
+            )
+        ) is False
+
+
+async def test_query_tracing_middleware_logs_summary_only_at_info(caplog):
+    async def handler(request):
+        tracer = query_tracing.get_active_tracer()
+        tracer.record_query(
+            table_name="flows_v3",
+            row_count=2,
+            db_time_ms=1.5,
+            success=True,
+            sql_template="SELECT * FROM flows_v3 WHERE flow_id = %s",
+        )
+        return web.Response(status=200)
+
+    request = make_mocked_request(
+        "GET",
+        "/flows",
+        headers={query_tracing.QUERY_TRACING_HEADER: "1"},
+    )
+
+    with patch.object(query_tracing, "QUERY_TRACING_ENABLED", True):
+        with caplog.at_level(logging.INFO, logger="QueryTracing"):
+            response = await query_tracing.query_tracing_middleware(request, handler)
+
+    assert response.status == 200
+    assert len(_query_trace_records(caplog)) == 1
+    assert len(_query_detail_records(caplog)) == 0
+    assert "query_count=1" in caplog.text
+    assert "total_rows=2" in caplog.text
+
+
+async def test_query_tracing_middleware_logs_query_details_at_debug(caplog):
+    long_sql = "SELECT " + "x" * 400
+
+    async def handler(request):
+        tracer = query_tracing.get_active_tracer()
+        tracer.record_query(
+            table_name="flows_v3",
+            row_count=1,
+            db_time_ms=2.0,
+            success=True,
+            sql_template=long_sql,
+        )
+        return web.Response(status=200)
+
+    request = make_mocked_request(
+        "GET",
+        "/flows",
+        headers={query_tracing.QUERY_TRACING_HEADER: "1"},
+    )
+
+    with patch.object(query_tracing, "QUERY_TRACING_ENABLED", True):
+        with caplog.at_level(logging.DEBUG, logger="QueryTracing"):
+            await query_tracing.query_tracing_middleware(request, handler)
+
+    assert len(_query_trace_records(caplog)) == 1
+    assert len(_query_detail_records(caplog)) == 1
+    assert long_sql[:query_tracing.QUERY_TRACING_SQL_PREVIEW_LIMIT] in caplog.text
+    assert long_sql[:query_tracing.QUERY_TRACING_SQL_PREVIEW_LIMIT + 1] not in caplog.text
+
+
+async def test_execute_sql_records_failed_queries():
+    fake_db = SimpleNamespace(logger=logging.getLogger("AsyncPostgresDB:test"))
+    table = AsyncFlowTablePostgres(fake_db)
+
+    with patch.object(query_tracing, "QUERY_TRACING_ENABLED", True):
+        with query_tracing.DBQueryTracer(capture_query_details=True) as tracer:
+            response, _ = await table.execute_sql(
+                select_sql="SELECT * FROM flows_v3 WHERE flow_id = %s",
+                values=["secret-flow-id"],
+                cur=_FailingCursor(),
+            )
+
+    assert response.response_code == 500
+    assert tracer.query_count == 1
+    assert tracer.total_rows == 0
+    assert tracer.queries[0]["success"] is False
+    assert tracer.queries[0]["error_type"] == "RuntimeError"
+    assert "secret-flow-id" not in tracer.queries[0]["sql"]
+    assert "%s" in tracer.queries[0]["sql"]
+
+
+async def test_execute_sql_uses_sql_template_not_values():
+    fake_db = SimpleNamespace(logger=logging.getLogger("AsyncPostgresDB:test"))
+    table = AsyncFlowTablePostgres(fake_db)
+    records = [{
+        "flow_id": "HelloFlow",
+        "user_name": "tester",
+        "ts_epoch": 1,
+        "tags": "[]",
+        "system_tags": "[]",
+    }]
+
+    with patch.object(query_tracing, "QUERY_TRACING_ENABLED", True):
+        with query_tracing.DBQueryTracer(capture_query_details=True) as tracer:
+            response, _ = await table.execute_sql(
+                select_sql="SELECT * FROM flows_v3 WHERE flow_id = %s",
+                values=["secret-flow-id"],
+                cur=_SuccessfulCursor(records),
+            )
+
+    assert response.response_code == 200
+    assert tracer.query_count == 1
+    assert tracer.total_rows == 1
+    assert "secret-flow-id" not in tracer.queries[0]["sql"]
+    assert "%s" in tracer.queries[0]["sql"]
+
+
+async def test_db_query_tracer_isolated_across_concurrent_tasks():
+    with patch.object(query_tracing, "QUERY_TRACING_ENABLED", True):
+        async def run_trace(table_name, rows):
+            with query_tracing.DBQueryTracer() as tracer:
+                await asyncio.sleep(0)
+                tracer.record_query(
+                    table_name=table_name,
+                    row_count=rows,
+                    db_time_ms=1.0,
+                    success=True,
+                )
+                await asyncio.sleep(0)
+                return tracer.summary()
+
+        first, second = await asyncio.gather(
+            run_trace("flows_v3", 1),
+            run_trace("runs_v3", 3),
+        )
+
+    assert first["query_count"] == 1
+    assert first["total_rows"] == 1
+    assert second["query_count"] == 1
+    assert second["total_rows"] == 3
+    assert query_tracing.get_active_tracer() is None


### PR DESCRIPTION
## Summary

Closes #5.

This PR adds request-scoped DB query tracing to the metadata service using a `ContextVar`-backed tracer plus an `aiohttp` middleware.

The tracing is fully opt-in:
- deployment must enable `QUERY_TRACING_ENABLED=1`
- a request must send `X-Metaflow-Trace-DB: 1`

When enabled for a request, the metadata service logs:
- `query_count`
- `total_rows`
- `db_time_ms`
- `request_time_ms`

at the end of the request, without changing any API payloads or schemas.

## What Changed

### Request lifecycle tracing
- Added a new shared tracing module for metadata DB request tracing.
- Added an `aiohttp` middleware that:
  - checks the opt-in tracing header
  - creates a request-local tracer
  - resets tracer state in `finally`
  - emits one INFO summary log per traced request
  - emits per-query DEBUG logs only when DEBUG logging is enabled

### DB instrumentation
- Instrumented the shared `execute_sql()` path used by metadata-service read APIs.
- Query timing is measured only around:
  - `execute(...)`
  - `fetchall()`
- Python row serialization is intentionally excluded from `db_time_ms`.

### Failure handling
- Failed queries are still traced.
- On query failure, the trace captures:
  - table name
  - elapsed DB time
  - `row_count=0`
  - `error_type`
- The original exception flow is preserved.

### Safe SQL logging
- Per-query SQL detail is only retained/logged when DEBUG is enabled.
- SQL previews are truncated.
- Bound parameter values are never logged; only the SQL template is recorded.

## Why This Approach

This implementation keeps the strong parts of the linked PR direction (`ContextVar` + middleware), but tightens the behavior in a few important ways:

- tracing is per-request, not “all requests whenever enabled”
- DB timing reflects actual DB work, not Python serialization overhead
- failed queries are included in traces
- detailed SQL logging is DEBUG-only to reduce overhead and noise
- the summary log format is stable and easy to use for follow-on benchmarking work

## Logging Behavior

For traced requests, the service logs one request summary like:

- method
- path
- status
- `query_count`
- `total_rows`
- `db_time_ms`
- `request_time_ms`

When the `QueryTracing` logger is in DEBUG, it also logs one line per query with:
- table
- success/failure
- row count
- DB time
- error type
- truncated SQL template

## Tests Added

### Unit tests
Added coverage for:
- tracer context setup/reset
- env/header activation behavior
- INFO-only summary logging
- DEBUG per-query logging
- failed query tracing
- SQL template safety (no bound values logged)
- `ContextVar` isolation across concurrent tasks

### Integration tests
Added coverage for:
- traced `GET /flows/{flow_id}/runs`
- traced `GET /flows/{flow_id}/runs/{run_number}/steps/{step_name}/tasks`
- no trace when the header is absent
- no trace when tracing is disabled

## Local Verification

Passed locally:
- `python3 -m py_compile ...`
- `git diff --check`
- `./.venv/bin/pytest services/metadata_service/tests/unit_tests/query_tracing_test.py -q`

Integration tests are included, but could not be completed end-to-end in this environment because the repo’s integration suite expects:
- a dedicated test Postgres at `db_test`
- the migration tooling (`goose`) available in the test environment

## Notes

This PR is intentionally scoped to metadata-service read tracing through `execute_sql()`. It does not expand tracing to:
- mutation paths
- healthcheck/direct cursor paths
- response metadata changes
- benchmark/reporting endpoints
